### PR TITLE
Add Letsencrypt SSL on Heroku support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,10 @@ gem 'kronic'
 
 group :production do
   gem 'newrelic_rpm'
+  gem 'platform-api', github: 'jalada/platform-api', branch: 'master'
+  gem 'letsencrypt-rails-heroku', github: 'cbetta/letsencrypt-rails-heroku'
+  gem 'rack-ssl-enforcer'
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,31 @@
+GIT
+  remote: git://github.com/cbetta/letsencrypt-rails-heroku.git
+  revision: 00e6a05fde4025536cfe0f9177d9c86ef53d2f5f
+  specs:
+    letsencrypt-rails-heroku (0.2.7)
+      acme-client (~> 0.4.0)
+      platform-api
+
+GIT
+  remote: git://github.com/jalada/platform-api.git
+  revision: 45ddb3c1a7e2c7f85d979c0791db18e99affb237
+  branch: master
+  specs:
+    platform-api (0.8.0)
+      heroics (~> 0.0.17)
+
 GEM
   remote: http://rubygems.org/
   specs:
+    acme-client (0.4.1)
+      faraday (~> 0.9, >= 0.9.1)
     addressable (2.4.0)
-    aws-sdk (2.6.9)
-      aws-sdk-resources (= 2.6.9)
-    aws-sdk-core (2.6.9)
+    aws-sdk (2.6.14)
+      aws-sdk-resources (= 2.6.14)
+    aws-sdk-core (2.6.14)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.9)
-      aws-sdk-core (= 2.6.9)
+    aws-sdk-resources (2.6.14)
+      aws-sdk-core (= 2.6.14)
     backports (3.6.8)
     builder (3.2.2)
     capybara (2.10.1)
@@ -25,6 +43,8 @@ GEM
     crass (1.0.2)
     database_cleaner (1.5.3)
     dotenv (2.1.1)
+    erubis (2.7.0)
+    excon (0.54.0)
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -33,6 +53,12 @@ GEM
     foreman (0.82.0)
       thor (~> 0.19.1)
     hashie (3.4.6)
+    heroics (0.0.17)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
+      netrc
     jmespath (1.3.1)
     json (1.8.3)
     jwt (1.5.6)
@@ -49,10 +75,12 @@ GEM
       capybara (~> 2.2)
       minitest (~> 5.0)
       rake
+    moneta (0.8.0)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    newrelic_rpm (3.16.3.323)
+    netrc (0.11.0)
+    newrelic_rpm (3.17.0.325)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     nokogumbo (1.4.9)
@@ -88,6 +116,7 @@ GEM
       rack
     rack-protection (1.5.3)
       rack
+    rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rack_csrf (2.5.0)
@@ -102,7 +131,7 @@ GEM
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4.1)
     sass (3.4.22)
-    sequel (4.39.0)
+    sequel (4.40.0)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -146,6 +175,7 @@ DEPENDENCIES
   kramdown
   kronic
   launchy
+  letsencrypt-rails-heroku!
   minitest
   minitest-capybara
   newrelic_rpm
@@ -155,8 +185,10 @@ DEPENDENCIES
   omniauth-github
   omniauth-twitter
   pg
+  platform-api!
   puma
   rack-flash3
+  rack-ssl-enforcer
   rack-test
   rack_csrf
   rack_session_access
@@ -173,4 +205,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ Then to force a rebuild of the app slug thereafter:
     scp /tmp/localdbname.dump wherever@you.want # or use S3
     heroku pgbackups:restore DATABASE 'http://url.goes.here/localdbname.dump'
 
+### Setting up autorenewing SSL certificates with Letsencrypt on Heroku
+
+Flow2 ships with built in Heroku SSL support, allowing you to roll out free SSL to your app using Heroku SNI SSL and free Letsencrypt certificates.
+
+To enable SSL:
+
+1. Ensure your app and running on Heroku on either a Hobby or Professional dyno
+2. Set up the [custom domain](https://devcenter.heroku.com/articles/custom-domains) you want to use and point it at your application.
+3. Follow the instructions on [this page](https://github.com/pixielabs/letsencrypt-rails-heroku#configuring) to set up the `ACME_DOMAIN`, `ACME_EMAIL`, `HEROKU_TOKEN` and `HEROKU_APP` environment variables.
+4. Enable Letsencrypt: `heroku config:add ENABLE_LETSENCRYPT=true`
+5. Change the DNS for your custom domain to the new SSL endpoint. Run `heroku domains` to see your new DNS target.
+6. Once your domain resolves to the new DNS target make sure `https` works fine in your browser
+7. Turn your site to be SSL only by running `heroku config:add FORCE_SSL=true`
+8. Enable auto-renewing by adding [a scheduled task](https://github.com/pixielabs/letsencrypt-rails-heroku#adding-a-scheduled-task) using the [Heroku scheduler](https://elements.heroku.com/addons/scheduler).
+
 ## FAQs
 
 **Why is it built in Sinatra/not using Rails/written in such a weird way?** Because first and foremost, it's software for me, and I wanted to have fun building it. I develop in quite an idiosyncratic way as I don't develop software professionally, work in a team, and I just do what I want, the way I want. Nonetheless, I have tried to ensure the *result* is of a high quality as that's all I care about.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,14 @@
 require 'sinatra/asset_pipeline/task'
 require 'rake/testtask'
+require 'rake/testtask'
+
+if ENV['ENABLE_LETSENCRYPT']
+  require 'letsencrypt-rails-heroku'
+  Letsencrypt.configure
+  spec = Gem::Specification.find_by_name 'letsencrypt-rails-heroku'
+  load "#{spec.gem_dir}/lib/tasks/letsencrypt.rake"
+end
+
 require './app'
 
 Sinatra::AssetPipeline::Task.define! Flow::App
@@ -23,7 +32,7 @@ desc "Delete all data in Redis"
 task :reset_redis do
 	puts "Are you REALLY SURE? Ctrl+C now if not."
 	STDIN.gets
-  Ohm.redis.call "FLUSHDB"
+  REDIS.flushall
   puts "Redis database flushed"
 end
 


### PR DESCRIPTION
I've added SSL support for on Heroku. This means you can now deploy Flow2 to Heroku and add Free (!) SSL to your app, with autorenewal and everything!
- Add `letsencrypt-rails-heroku` gem  (awaiting merger of changes made to make it non-Rails specific)
- Add `rack-ssl-enforcer` to help enforce SSL
- Load rake tasks
- Add code to insert Letsencrypt and SSL Enforcer middleware when right correct flags are set

Also: 
- Fixed a last remaining Ohm statement

FYI this is up and running on https://news.devrel.net/.

Please hold off on merging until the changes in the `letsencrypt-rails-heroku` gem are merged.
